### PR TITLE
fix: prealloc when making CETs

### DIFF
--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -548,7 +548,7 @@ pub fn create_cets(
     payouts: &[Payout],
     lock_time: u32,
 ) -> Vec<Transaction> {
-    let mut txs: Vec<Transaction> = Vec::new();
+    let mut txs: Vec<Transaction> = Vec::with_capacity(payouts.len());
     for payout in payouts {
         let offer_output = TxOut {
             value: payout.offer,


### PR DESCRIPTION
Found while investigating existing benchmarks for the signing and verify logic. `create_cets()` is infallible so this should be fine.